### PR TITLE
bft(b from top) discriminator added to dnn2

### DIFF
--- a/Cutflow.py
+++ b/Cutflow.py
@@ -1,51 +1,30 @@
 #ng histograms and save in a pdf.
 # e.g. tthh
-
 import ROOT
 import numpy as np
 
 # Criteria
-PRE = "CUT_FFULL_1130_14TeV"
+PRE = "CF_1216_14TeV"
 Tree = "Delphes"
 print(PRE)
 
 # Input
-tthh = "samples2/" + PRE + "_tthh_di.root"
-ttbbbb = "samples2/" + PRE + "_ttbbbb_di.root"
-ttbbcc = "samples2/" + PRE + "_ttbbcc_di.root"
-ttbb = "samples2/" + PRE + "_ttbb_di.root"
-tthbb = "samples2/" + PRE + "_tthbb_di.root"
+tthh = "samples1/" + PRE + "_tthh_di.root"
+ttbbbb = "samples1/" + PRE + "_ttbbbb_di.root"
+ttbbcc = "samples1/" + PRE + "_ttbbcc_di.root"
+ttbb = "samples1/" + PRE + "_ttbb_di.root"
+tthbb = "samples1/" + PRE + "_tthbb_di.root"
 TreeName = "Delphes"
 
 # Luminosity [fb^-1]
 L = 3000
 
-# MODIFY!!
-# Cross section * Luminosity = Expected Events
-# [DiLeptonic]
-'''
-x_tthh = 3.791e-2 *L
-x_ttbbbb = 3.1e-1 *L
-x_ttbbcc = 5.012e-1 *L
-x_ttbb = 1.076e2 *L
-x_tthbb = 2.105e1 *L
-'''
-
-# [DiLeptonic_HLLHC]
+# [HLLHC : DiLeptonic]
 x_tthh = 4.113e-05  *L * 1000
-x_ttbbbb =  0.0004423 *L * 1000
-x_ttbbcc = 0.0006947 *L * 1000
-x_ttbb = 0.1321 *L * 1000
-x_tthbb = 0.02261 *L * 1000
-
-
-# [SemiLeptonic] ; *2 -> Generated sampeles partially(W+, W-) and merged.
-#x_tthh = 1.139e-4 *L * 1000 * 2  # CHECK AGAIN
-#x_tthh = 1.139e-4 *L * 1000 * 2 
-#x_ttbbbb = 0.049 *L * 1000 * 2
-#x_ttbbcc = 0.0137 *L * 1000 * 2
-#x_ttbb = 2.287 *L * 1000 * 2 
-
+x_ttbbbb =  4.405e-04 *L * 1000
+x_ttbbcc = 6.929e-04 *L * 1000
+x_ttbb =  1.303e-01 *L * 1000  # 1.315e-01 was original. - x_ttbbbb, bbcc.
+x_tthbb = 2.261e-02 *L * 1000
 
 # RDF
 tthh = ROOT.RDataFrame(Tree, tthh)
@@ -57,33 +36,24 @@ tthbb = ROOT.RDataFrame(Tree, tthbb)
 print("Calculating Acceptance and Cutflow")
 
 # MODIFY!! E.S.
-def Acceptance(df):
+def Acceptance(df, df_name):
     Accept = []
     S0 = float(df.Count().GetValue())
-    df = df.Filter("Lep_size >= 2"); S1 = float(df.Count().GetValue())
+    df = df.Filter("Lep_size == 2 && Lep1_pt > 17 && Lep2_pt > 10"); S1 = float(df.Count().GetValue())
     df = df.Filter("Jet_size >= 5"); S2 = float(df.Count().GetValue())
     df = df.Filter("bJet_size >= 5"); S3 = float(df.Count().GetValue())
-    Accept.extend([S0,S1,S2,S3])
+    DNN = float(input(f"{df_name} DNN Efficiency = "))
+    S4 = S3 * DNN
+    Accept.extend([S0,S1,S2,S3, S4])
     print(Accept)
     return Accept
-    '''Yeild
-    print("noCut : ", S0 , (S0/S0)*100, "%")
-    print("S1 : ", S1, (S1/S0)*100, "%")
-    print("S2 : ", S2, (S2/S0)*100, "%")
-    print("S3 : ", S3, (S3/S0)*100, "%")
-    '''
 
 print("________ACCEPTANCE________")
-print("tthh")    
-tthh = Acceptance(tthh)
-print("ttbbbb")
-ttbbbb = Acceptance(ttbbbb)
-print("ttbbcc")
-ttbbcc = Acceptance(ttbbcc)
-print("ttbb")
-ttbb = Acceptance(ttbb)
-print("tthbb")
-tthbb = Acceptance(tthbb)
+tthh = Acceptance(tthh, "tthh")
+ttbbbb = Acceptance(ttbbbb, "ttbbbb")
+ttbbcc = Acceptance(ttbbcc, "ttbbcc")
+ttbb = Acceptance(ttbb, "ttbb")
+tthbb = Acceptance(tthbb, "tthbb")
 
 Acc = {
     "tthh" : [tthh, x_tthh/tthh[0]], 
@@ -101,14 +71,14 @@ def Cutflow(Acc):
     return Acc
 
 print("__________CUTFLOW__________")        
-Acc_re = Cutflow(Acc)
+CF = Cutflow(Acc)
 
 print(" ")
 print("________SIGNIFICANCE________")
 
 # Significance # Modify! # 
-for i in range(0,4):
-    print("Siignificance of ES :", i)
-    print(Acc_re["tthh"][0][i]/np.sqrt(Acc_re["tthh"][0][i]+Acc_re["ttbbbb"][0][i]+Acc_re["ttbbcc"][0][i]+Acc_re["ttbb"][0][i]+Acc_re["tthbb"][0][i]))
+for i in range(0,5):
+    print("Significance of ES :", i)
+    print(CF["tthh"][0][i]/np.sqrt(CF["tthh"][0][i]+CF["ttbbbb"][0][i]+CF["ttbbcc"][0][i]+CF["ttbb"][0][i]+CF["tthbb"][0][i]))
     print("----Done----")
 

--- a/ana_tthh_df.C
+++ b/ana_tthh_df.C
@@ -52,7 +52,6 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
                   .Define("GenMissingET_eta", "GenMissingET.Eta")
                   .Define("GenMissingET_phi", "GenMissingET.Phi");
                   
-
     // Gen and Matching //
     auto df1 = df0.Define("isLast", ::isLast, {"Particle.PID", "Particle.D1", "Particle.D2"})
                   .Define("Top", "abs(Particle.PID) == 6 && isLast").Define("nTop", "Sum(Top)")
@@ -97,8 +96,12 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
                   .Define("Q_Higgs2_mass", "Q_Higgs2_var[3]")
                   .Define("Q_Higgs_mass", ::ConcatFloat, {"Q_Higgs1_mass", "Q_Higgs2_mass"})
 
+                  // GenJet
+                  .Define("GenJet_Avg", ::Avg, {"GenJet.PT", "GenJet.Eta", "GenJet.Phi", "GenJet.Mass"})
+                  .Define("GenJet_dr_avg", "GenJet_Avg[0]")
+                  .Define("GenJet_dEta_avg", "GenJet_Avg[1]")
+                  .Define("GenJet_dPhi_avg", "GenJet_Avg[2]")
 
-                  
                   // Gen bJet Matching
                   .Define("GenbJetFromTop1_idx", ::dRMatching_idx, {"GenbFromTop1_idx", "drmax2", "Particle.PT", "Particle.Eta", "Particle.Phi", "Particle.Mass", "GenJet.PT", "GenJet.Eta", "GenJet.Phi", "GenJet.Mass"})
                   .Define("GenbJetFromTop2_idx", ::dRMatching_idx, {"GenbFromTop2_idx", "drmax2", "Particle.PT", "Particle.Eta", "Particle.Phi", "Particle.Mass", "GenJet.PT", "GenJet.Eta", "GenJet.Phi", "GenJet.Mass"})
@@ -175,11 +178,26 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
                   .Define("GenHiggs1_eta", "GenHiggs1_var[1]")
                   .Define("GenHiggs1_phi", "GenHiggs1_var[2]")
                   .Define("GenHiggs1_mass", "GenHiggs1_var[3]")
+                  .Define("GenHiggs1_bdr", "GenHiggs1_var[4]")
+                  .Define("GenHiggs1_Ht", "GenHiggs1_var[5]")
+                  .Define("GenHiggs1_dEta", "GenHiggs1_var[6]")
+                  .Define("GenHiggs1_dPhi", "GenHiggs1_var[7]")
+                  .Define("GenHiggs1_mbmb", "GenHiggs1_var[8]")
                   .Define("GenHiggs2_pt", "GenHiggs2_var[0]")
                   .Define("GenHiggs2_eta", "GenHiggs2_var[1]")
                   .Define("GenHiggs2_phi", "GenHiggs2_var[2]")
                   .Define("GenHiggs2_mass", "GenHiggs2_var[3]")
-                  .Define("GenHiggs_mass", ::ConcatFloat, {"GenHiggs1_mass", "GenHiggs2_mass"});
+                  .Define("GenHiggs2_bdr", "GenHiggs2_var[4]")
+                  .Define("GenHiggs2_Ht", "GenHiggs2_var[5]")
+                  .Define("GenHiggs2_dEta", "GenHiggs2_var[6]")
+                  .Define("GenHiggs2_dPhi", "GenHiggs2_var[7]")
+                  .Define("GenHiggs2_mbmb", "GenHiggs2_var[8]")
+                  .Define("GenHiggs_mass", ::ConcatFloat, {"GenHiggs1_mass", "GenHiggs2_mass"})
+                  .Define("GenHiggs_bdr", ::ConcatFloat, {"GenHiggs1_bdr", "GenHiggs2_bdr"})
+                  .Define("GenHiggs_Ht", ::ConcatFloat, {"GenHiggs1_Ht", "GenHiggs2_Ht"})
+                  .Define("GenHiggs_dEta", ::ConcatFloat, {"GenHiggs1_dEta", "GenHiggs2_dEta"})
+                  .Define("GenHiggs_dPhi", ::ConcatFloat, {"GenHiggs1_dPhi", "GenHiggs2_dPhi"})
+                  .Define("GenHiggs_mbmb", ::ConcatFloat, {"GenHiggs1_mbmb", "GenHiggs2_mbmb"});
 
     // Reco Matching //
     auto df3 = df2.Define("b1JetFromHiggs1_pt", ::idx_var, {"Jet.PT", "b1JetFromHiggs1_idx"})
@@ -189,11 +207,10 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
                   .Define("bJetFromTop1_pt", ::idx_var, {"Jet.PT", "bJetFromTop1_idx"})
                   .Define("bJetFromTop2_pt", ::idx_var, {"Jet.PT", "bJetFromTop2_idx"});
                   
-
     // Reco //
-    auto df4 = df3.Define("goodJet", "Jet.PT>=25 && abs(Jet.Eta)<2.8")
-                  .Define("goodElectron", "Electron.PT>=15 && abs(Electron.Eta)<2.8")
-                  .Define("goodMuon", "Muon.PT>=15 && abs(Muon.Eta)<2.8")
+    auto df4 = df3.Define("goodJet", "Jet.PT>=25 && abs(Jet.Eta)<3.0")
+                  .Define("goodElectron", "Electron.PT>=10 && abs(Electron.Eta)<2.8")
+                  .Define("goodMuon", "Muon.PT>=10 && abs(Muon.Eta)<2.8")
 
                   .Define("Jet_pt", "Jet.PT[goodJet]")
                   .Define("Jet_eta", "Jet.Eta[goodJet]")
@@ -235,8 +252,8 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
                   .Define("MET_Eta", "MissingET.Eta")
                   .Define("MET_Phi", "MissingET.Phi")
                   // You Must Use [bi_Tag] Before Filter // 
-
-                  .Filter("Lep_size >= 2")
+                  
+                  .Filter("Lep_size == 2 && Lep1_pt > 17 && Lep2_pt > 10")
                   .Filter("Jet_size >= 5")
                   .Filter("bJet_size >= 5")
                   .Define("bJet_pt_scheme", ::pt_scheme, {"b1JetFromHiggs1_pt", "b2JetFromHiggs1_pt", "b1JetFromHiggs2_pt", "b2JetFromHiggs2_pt", "bJetFromTop1_pt", "bJetFromTop2_pt"})
@@ -297,6 +314,7 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
                   .Define("b4b5_dr", ::dR2, {"bJet4_pt", "bJet4_eta", "bJet4_phi", "bJet4_mass", "bJet5_pt", "bJet5_eta", "bJet5_phi", "bJet5_mass"})
                   .Define("bb_dr", ::ConcatFloat_withoutSort_10, {"b1b2_dr", "b1b3_dr", "b1b4_dr", "b1b5_dr", "b2b3_dr", "b2b4_dr", "b2b5_dr", "b3b4_dr", "b3b5_dr", "b4b5_dr"})
 
+                  
                   .Define("b_Vars", ::Vars, {"bb_dr", "bJet_pt", "bJet_eta", "bJet_phi", "bJet_mass", "bJet_E"})
                   .Define("bb_avg_dr", "b_Vars[0]")
                   .Define("bb_max_dr", "b_Vars[1]")
@@ -323,7 +341,11 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
                   .Define("bCat_higgs5_2", ::bCat_higgs5_2, {"b1", "b2", "b3", "b4", "b5"})
                   .Define("bCat_higgs5_3", ::bCat_higgs5_3, {"b1", "b2", "b3", "b4", "b5"})
                   .Define("bCat_higgs5_2Mat", ::bCat_higgs5_2Mat, {"b1", "b2", "b3", "b4", "b5"})
-                  .Define("bCat_top_1", ::bCat_top_1, {"b1", "b2", "b3", "b4", "b5"});
+                  .Define("bCat_top_1", ::bCat_top_1, {"b1", "b2", "b3", "b4", "b5"})
+
+                  .Define("Event_shapes", ::Event_shapes, {"bJet_pt", "bJet_eta", "bJet_phi", "bJet_mass"})
+                  .Define("aplanarity", "Event_shapes[0]")
+                  .Define("sphericity", "Event_shapes[1]");
                   
 
     // Reconstruction of Higgs //
@@ -338,9 +360,10 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
                   .Define("Chi_min", "RecoHiggs[7]");
 
 
-    auto df6 = df5.Filter("isMatchable > 0"); 
+//    auto df6 = df5.Filter("isMatchable > 0"); 
 
     std::initializer_list<std::string> variables = {
+
     "ParticlePID", "ParticlePT", "D1", "D2", "JetBTag", 
     "Top1_idx", "GenbFromTop1_idx", "Top2_idx", "GenbFromTop2_idx", 
     "Higgs1_idx", "Genb1FromHiggs1_idx", "Genb2FromHiggs1_idx",
@@ -350,7 +373,17 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
     "nGenbJet", "nbJet",
 
     "bQuarkFromTop1_pt", "bQuarkFromTop2_pt", "b1QuarkFromHiggs1_pt", "b2QuarkFromHiggs1_pt", "b1QuarkFromHiggs2_pt", "b2QuarkFromHiggs2_pt",
+
+    // Comparison
+    "GenJet_Avg", "GenJet_dr_avg", "GenJet_dEta_avg", "GenJet_dPhi_avg",
+    // DNN Vars Candidates 
     "GenHiggs_mass", "GenHiggs1_mass", "GenHiggs2_mass",
+    "GenHiggs1_bdr", "GenHiggs2_bdr", "GenHiggs_bdr", 
+    "GenHiggs1_Ht", "GenHiggs2_Ht", "GenHiggs_Ht", 
+    "GenHiggs1_dEta", "GenHiggs2_dEta", "GenHiggs_dEta", 
+    "GenHiggs1_dPhi", "GenHiggs2_dPhi", "GenHiggs_dPhi", 
+    "GenHiggs1_mbmb", "GenHiggs2_mbmb", "GenHiggs_mbmb", 
+
     "Q_Higgs_mass", "Q_Higgs1_mass", "Q_Higgs2_mass",
     "Genb1JetFromHiggs1_pt", "Genb2JetFromHiggs1_pt", "Genb1JetFromHiggs2_pt", "Genb2JetFromHiggs2_pt", 
     "GenbJetFromTop1_pt", "GenbJetFromTop2_pt",
@@ -360,6 +393,8 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
     "GenMuddiness",
     "Overlap_bt1", "Overlap_bt2", "Overlap_b1h1", "Overlap_b2h1", "Overlap_b1h2", "Overlap_b2h2",
     "Muddiness",
+
+    "nMatchedbJet",
                      
     "GenbJet_pt_scheme",
     "b1", "b2", "b3", "b4", "nMatched_bFromTop", "nMatched_bFromHiggs", "nMatched_bJet",
@@ -368,7 +403,7 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
 
     //----------------Reco---------------------//
 
-    "Jet_pt", "Jet_eta", "Jet_phi", "Jet_mass", "Jet_size",
+     "Jet_pt", "Jet_eta", "Jet_phi", "Jet_mass", "Jet_size",
      "bJet_pt", "bJet_eta", "bJet_phi", "bJet_mass", "bJet_size",
      "Jet1_pt", "Jet1_eta", "Jet1_phi", "Jet1_mass",
      "Jet2_pt", "Jet2_eta", "Jet2_phi", "Jet2_mass",
@@ -393,17 +428,19 @@ void ana_tthh_df(std::string channel, std::string outdir="./samples1/"){
      "MET_E", "MET_Eta", "MET_Phi",
 
     //----------------New-----------------------//
+
      "bb_dr", "b_Vars", "bb_avg_dr", "bb_max_dr", "bb_min_dr", "b_ht", "bb_dEta_WhenMaxdR", "b_cent", "bb_max_deta", "bb_max_mass", "bb_twist",
     "jj_dr", "j_Vars", "jj_avg_dr", "jj_max_dr", "jj_min_dr", "j_ht", "jj_dEta_WhenMaxdR", "j_cent", "jj_max_deta", "jj_max_mass", "jj_twist", 
     "close_Higgs_pt", "close_Higgs_eta", "close_Higgs_phi", "close_Higgs_mass",
 
-     "isMatchable", "Matched_idx1", "Matched_idx2", "Correct_Chi", "Chi_min",
-//    "Lep_size", "Jet_size", "bJet_size",
+     "isMatchable", "Matched_idx1", "Matched_idx2", "Correct_Chi", "Chi_min", 
+     "Event_shapes", "aplanarity", "sphericity",
+
     };
 
     // MODIFY!!
-    df5.Snapshot(treename, outdir+ "FULL_1204_14TeV_" + channel + ".root", variables); 
-    df6.Snapshot(treename, outdir+ "FULL_1204_14TeV_Matchable_" + channel + ".root", variables); 
+    df5.Snapshot(treename, outdir+ "FULL_1218_14TeV_" + channel + ".root", variables); 
+//    df6.Snapshot(treename, outdir+ "SAM_1207_14TeV_Matchable_" + channel + ".root", variables); 
     std::cout << "done" << std::endl; 
 
     //df.Snapshot<TClonesArray, TClonesArray, TClonesArray, TClonesArray>("outputTree", "out.root", variables, ROOT::RDF::RSnapshotOptions("RECreate", ROOT::kZLIB, 1, 0, 99, false));

--- a/dnn1_bft.py
+++ b/dnn1_bft.py
@@ -21,13 +21,12 @@ from sklearn.model_selection import train_test_split
 #                     I/O                         #
 ###################################################
 indir = "./samples1/"; PRE = "B_1217_14TeV" # Should be apart from data for event classification.
-outdir = "./DNN_result/" + PRE + "/bJetCassification/bCat_higgs5_2Mat/" # MODIFY #
+outdir = "./DNN_result/" + PRE + "/bJetCassification/bCat_top_1/" # MODIFY #
 os.makedirs(outdir, exist_ok=True)
-class_names = ["Cat1", "Cat2", "Cat3", "Cat4", "Cat5", "Cat6", "Cat7", "Cat8", "Cat9", "Cat10", "NoCat"]
+class_names = ["Cat1", "Cat2", "Cat3", "Cat4", "Cat5", "NoCat"]
 
 inputvars = [
 
-#     "bJet_size",
      "bJet1_pt", "bJet1_eta", "bJet1_phi", "bJet1_mass",
      "bJet2_pt", "bJet2_eta", "bJet2_phi", "bJet2_mass",
      "bJet3_pt", "bJet3_eta", "bJet3_phi", "bJet3_mass",
@@ -40,26 +39,33 @@ inputvars = [
      "b3b4_dr", "b3b5_dr",
      "b4b5_dr",
 
+     # Lepton
+#     "bJet_size",
+#     "Lep_size",
+#     "Lep1_pt", "Lep1_eta", "Lep1_phi", "Lep1_t",
+#     "Lep2_pt", "Lep2_eta", "Lep2_phi", "Lep2_t",
+#     "MET_E", # why decrease..
+
+
+     # Defined Kinematic vars
+#     "bb_max_dr", "bb_min_dr", "b_ht", "bb_dEta_WhenMaxdR", "b_cent", "bb_max_deta", "bb_max_mass", "bb_twist",
+#     "close_Higgs_pt", "close_Higgs_phi", "close_Higgs_mass", "close_Higgs_eta",
+
             ]
 
-catvar = ["bCat_higgs5_2Mat"] # MODIFY #
+catvar = ["bCat_top_1"] # MODIFY #
 openvars = inputvars + catvar
 
 ###################################################
 #                 PreProcessing                   #
 ###################################################
 pd_data = uproot.open(indir+PRE+"_tthh_di.root")["Delphes"].arrays(openvars,library="pd")
-pd_cat1 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 0]
-pd_cat2 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 1]
-pd_cat3 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 2]
-pd_cat4 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 3]
-pd_cat5 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 4]
-pd_cat6 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 5]
-pd_cat7 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 6]
-pd_cat8 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 7]
-pd_cat9 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 8]
-pd_cat10 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 9]
-pd_cat11 = pd_data.loc[pd_data["bCat_higgs5_2Mat"] == 10]
+pd_cat1 = pd_data.loc[pd_data["bCat_top_1"] == 0]
+pd_cat2 = pd_data.loc[pd_data["bCat_top_1"] == 1]
+pd_cat3 = pd_data.loc[pd_data["bCat_top_1"] == 2]
+pd_cat4 = pd_data.loc[pd_data["bCat_top_1"] == 3]
+pd_cat5 = pd_data.loc[pd_data["bCat_top_1"] == 4]
+pd_cat6 = pd_data.loc[pd_data["bCat_top_1"] == 5]
 
 nCat1 = len(pd_cat1) 
 nCat2 = len(pd_cat2)
@@ -67,12 +73,7 @@ nCat3 = len(pd_cat3)
 nCat4 = len(pd_cat4)
 nCat5 = len(pd_cat5)
 nCat6 = len(pd_cat6)
-nCat7 = len(pd_cat7)
-nCat8 = len(pd_cat8)
-nCat9 = len(pd_cat9)
-nCat10 = len(pd_cat10)
-nCat11 = len(pd_cat11)
-ntrain = min(nCat1, nCat2, nCat3, nCat4, nCat5, nCat6, nCat7, nCat8, nCat9, nCat10)#, nCat11)
+ntrain = min(nCat1, nCat2, nCat3, nCat4, nCat5, nCat6)
 print("ntrain = ", ntrain)
 
 pd_cat1 = pd_cat1.sample(n=ntrain).reset_index(drop=True)
@@ -81,18 +82,13 @@ pd_cat3 = pd_cat3.sample(n=ntrain).reset_index(drop=True)
 pd_cat4 = pd_cat4.sample(n=ntrain).reset_index(drop=True)
 pd_cat5 = pd_cat5.sample(n=ntrain).reset_index(drop=True)
 pd_cat6 = pd_cat6.sample(n=ntrain).reset_index(drop=True)
-pd_cat7 = pd_cat7.sample(n=ntrain).reset_index(drop=True)
-pd_cat8 = pd_cat8.sample(n=ntrain).reset_index(drop=True)
-pd_cat9 = pd_cat9.sample(n=ntrain).reset_index(drop=True)
-pd_cat10 = pd_cat10.sample(n=ntrain).reset_index(drop=True)
-pd_cat11 = pd_cat11.sample(n=ntrain).reset_index(drop=True)
 print("pd_cat1", pd_cat1)
 
-pd_data = pd.concat([pd_cat1, pd_cat2, pd_cat3, pd_cat4, pd_cat5, pd_cat6, pd_cat7, pd_cat8, pd_cat9, pd_cat10, pd_cat11])
+pd_data = pd.concat([pd_cat1, pd_cat2, pd_cat3, pd_cat4, pd_cat5, pd_cat6])
 pd_data = pd_data.sample(frac=1).reset_index(drop=True)
 print("pd_data", pd_data)
 x_total = np.array(pd_data.filter(items = inputvars))
-y_total = np.array(pd_data.filter(items = ['bCat_higgs5_2Mat'])) # MODIFY #
+y_total = np.array(pd_data.filter(items = ['bCat_top_1'])) # MODIFY #
 
 # Training and Cross-Validation Set
 x_train, x_val, y_train, y_val = train_test_split(x_total, y_total, test_size=0.3)
@@ -101,7 +97,7 @@ print("x_train: ",len(x_train),"x_val: ", len(x_val),"y_train: ", len(y_train),"
 ###################################################
 #                      Model                      #
 ###################################################
-epochs = 1000; patience_epoch = 10; batch_size = 512; print("batch size :", batch_size)
+epochs = 1000; patience_epoch = 30; batch_size = 512; print("batch size :", batch_size)
 activation_function='relu'
 weight_initializer = 'random_normal'
 es = EarlyStopping(monitor='val_loss', mode='min', verbose=1, patience=patience_epoch)
@@ -114,7 +110,10 @@ model.add(tf.keras.layers.Flatten(input_shape = (x_train.shape[1],)))
 model.add(tf.keras.layers.BatchNormalization())
 model.add(tf.keras.layers.Dense(30, activation=activation_function))
 model.add(tf.keras.layers.BatchNormalization())
-model.add(tf.keras.layers.Dense(100, activation=activation_function, kernel_regularizer='l2', kernel_initializer=weight_initializer))
+model.add(tf.keras.layers.Dense(20, activation=activation_function))
+#model.add(tf.keras.layers.BatchNormalization())
+model.add(tf.keras.layers.Dropout(0.2))    
+model.add(tf.keras.layers.Dense(20, activation=activation_function, kernel_regularizer='l2', kernel_initializer=weight_initializer))
 ###############    Output Layer     ###############
 print("class_names : ", len(class_names))
 model.add(tf.keras.layers.Dense(len(class_names), activation="softmax"))

--- a/utils/var_functions.py
+++ b/utils/var_functions.py
@@ -1,8 +1,110 @@
-# Build functions make additional variables with DNN result, "pred_bcat"
+# Build functions make additional variables with DNN result, "pred_bfh"
+import os
 import numpy as np
+import matplotlib.pyplot as plt
+
+def plot_histogram(data, title, x_label, y_label, save_dir):
+    hist_values, bin_edges = np.histogram(data, bins=20)
+    bin_centers = 0.5 * (bin_edges[:-1] + bin_edges[1:])
+    bin_width = bin_edges[1] - bin_edges[0]
+    errors = np.sqrt(hist_values)
+    
+    plt.bar(bin_centers, hist_values, width=bin_width, color='blue', alpha=0.7)
+    plt.errorbar(bin_centers, hist_values, yerr=errors, fmt='d', color='red', markersize=6, capsize=5)
+    
+    plt.title(title)
+    plt.xlabel(x_label)
+    plt.ylabel(y_label)
+    file_name = title.replace(" ", "_").lower() + ".pdf"
+    save_path = os.path.join(save_dir, file_name)
+    plt.savefig(save_path, format='pdf')
+    plt.close()
+
+def plot_2histogram(df, col1, col2, title, x_label, y_label, save_dir):
+    data1 = df[col1]
+    data2 = df[col2]
+
+    hist_values1, bin_edges1 = np.histogram(data1, bins=20)
+    bin_centers1 = 0.5 * (bin_edges1[:-1] + bin_edges1[1:])
+    bin_width1 = bin_edges1[1] - bin_edges1[0]
+    errors1 = np.sqrt(hist_values1)
+
+    hist_values2, bin_edges2 = np.histogram(data2, bins=20)
+    bin_centers2 = 0.5 * (bin_edges2[:-1] + bin_edges2[1:])
+    bin_width2 = bin_edges2[1] - bin_edges2[0]
+    errors2 = np.sqrt(hist_values2)
+
+    plt.bar(bin_centers1, hist_values1, width=bin_width1, color='blue', alpha=0.5, label=col1)
+    plt.bar(bin_centers2, hist_values2, width=bin_width2, color='green', alpha=0.5, label=col2)
+    plt.errorbar(bin_centers1, hist_values1, yerr=errors1, fmt='none', color='blue', markersize=6, capsize=5)
+    plt.errorbar(bin_centers2, hist_values2, yerr=errors2, fmt='none', color='green', markersize=6, capsize=5)
+
+    plt.title(title)
+    plt.xlabel(x_label)
+    plt.ylabel(y_label)
+    plt.legend()
+    file_name = title.replace(" ", "_").lower() + ".pdf"
+    save_path = os.path.join(save_dir, file_name)
+    plt.savefig(save_path, format='pdf')
+    plt.close()
+
+def plot_multi_histograms(dataframe, histogram_name, x_label, y_label, outdir, *args):
+    plt.figure(figsize=(10, 6))
+
+    for arg in args:
+        column_name, label, color, histtype = arg
+        data = dataframe[column_name]
+        data = data[data > 0]
+
+        n, bins, patches = plt.hist(data, bins=30, density=True, alpha=0.5, label=label, color=color, histtype=histtype)
+
+        bin_centers = 0.5 * (bins[:-1] + bins[1:])
+        bin_width = bins[1] - bins[0]
+        bin_heights = n / (len(data) * bin_width)
+        errors = np.sqrt(n) / (len(data) * bin_width)
+        plt.errorbar(bin_centers, bin_heights, yerr=errors, fmt='none', color=color)
+
+    plt.xlabel(x_label)
+    plt.ylabel(y_label)
+    plt.title(histogram_name)
+    plt.legend()
+    
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+    save_filename = f'{histogram_name.replace(" ", "_")}.pdf'
+    save_path = os.path.join(outdir, save_filename)
+    plt.savefig(save_path)
+    plt.show()
+
+def plot_multi_histograms_dfs(column_name, histogram_name, x_label, y_label, outdir, *args):
+    plt.figure(figsize=(10, 6))
+
+    for dataframe, label, color, histtype in args:
+        data = dataframe[column_name]
+        data = data[data > 0]
+
+        n, bins, patches = plt.hist(data, bins=30, density=True, alpha=0.5, label=label, color=color, histtype=histtype)
+
+        bin_centers = 0.5 * (bins[:-1] + bins[1:])
+        bin_width = bins[1] - bins[0]
+        bin_heights = n / (len(data) * bin_width)
+        errors = np.sqrt(n) / (len(data) * bin_width)
+        plt.errorbar(bin_centers, bin_heights, yerr=errors, fmt='none', color=color)
+
+    plt.xlabel(x_label)
+    plt.ylabel(y_label)
+    plt.title(histogram_name)
+    plt.legend()
+
+    if not os.path.exists(outdir):
+        os.makedirs(outdir)
+    save_filename = f'{histogram_name.replace(" ", "_")}.pdf'
+    save_path = os.path.join(outdir, save_filename)
+    plt.savefig(save_path)
+    plt.show()
 
 def higgs5_3(row):
-    cat = row["pred_bcat"]
+    cat = row["pred_bfh"]
     pts = ["bJet1_pt", "bJet2_pt", "bJet3_pt", "bJet4_pt", "bJet5_pt"]
     etas = ["bJet1_eta", "bJet2_eta", "bJet3_eta", "bJet4_eta", "bJet5_eta"]
     phis = ["bJet1_phi", "bJet2_phi", "bJet3_phi", "bJet4_phi", "bJet5_phi"]
@@ -41,8 +143,62 @@ def higgs5_3(row):
         return close_mass
     else: return 0
 
+
+def calculate_mass(pt1, eta1, phi1, m1, pt2, eta2, phi2, m2):
+    px1, px2 = pt1 * np.cos(phi1), pt2 * np.cos(phi2)
+    py1, py2 = pt1 * np.sin(phi1), pt2 * np.sin(phi2)
+    pz1, pz2 = pt1 * np.sinh(eta1), pt2 * np.sinh(eta2)
+    E1, E2 =np.sqrt(pt1**2+m1**2)*np.cosh(eta1),np.sqrt(pt2**2+m2**2)*np.cosh(eta2)
+    pxs = [px1, px2]; pys = [py1, py2]; pzs = [pz1, pz2]; Es = [E1, E2]
+
+    px_1, py_1, pz_1, E_1 = pxs[0], pys[0], pzs[0], Es[0]
+    px_2, py_2, pz_2, E_2 = pxs[1], pys[1], pzs[1], Es[1]
+
+    px = px_1 + px_2
+    py = py_1 + py_2
+    pz = pz_1 + pz_2
+    E = E_1 + E_2
+
+    mass = np.sqrt(E**2 - px**2 - py**2 - pz**2)
+    return mass
+
+
 def higgs_5_2(row):
-    cat = row["pred_bcat"]
+    cat = row["pred_bfh"]
+    bfts = ["bft_1", "bft_2", "bft_3", "bft_4", "bft_5"]
+    pts = ["bJet1_pt", "bJet2_pt", "bJet3_pt", "bJet4_pt", "bJet5_pt"]
+    etas = ["bJet1_eta", "bJet2_eta", "bJet3_eta", "bJet4_eta", "bJet5_eta"]
+    phis = ["bJet1_phi", "bJet2_phi", "bJet3_phi", "bJet4_phi", "bJet5_phi"]
+    ms = ["bJet1_mass", "bJet2_mass", "bJet3_mass", "bJet4_mass", "bJet5_mass"]
+    arrow = {0:[0,1], 1:[0,2], 2:[0,3], 3:[0,4], 4:[1,2], 5:[1,3], 6:[1,4], 7:[2,3], 8:[2,4], 9:[3,4]}
+    arrow2 = {0:[2,3,4], 1:[1,3,4], 2:[1,2,4], 3:[1,2,3], 4:[0,3,4], 5:[0,2,4], 6:[0,2,3], 7:[0,1,4], 8:[0,1,3], 9:[0,1,2]}
+    if cat == 10: return [0, 0];
+
+    # higgs_1
+    pt1, pt2 = row[pts[arrow[cat][0]]], row[pts[arrow[cat][1]]]
+    eta1, eta2 = row[etas[arrow[cat][0]]], row[etas[arrow[cat][1]]]
+    phi1, phi2 = row[phis[arrow[cat][0]]], row[phis[arrow[cat][1]]]
+    m1, m2 = row[ms[arrow[cat][0]]], row[ms[arrow[cat][1]]]
+    higgs_mass_1 = calculate_mass(pt1, eta1, phi1, m1, pt2, eta2, phi2, m2)
+
+    # higgs_2
+    bfts = np.array([ row[bfts[arrow2[cat][0]]], row[bfts[arrow2[cat][1]]], row[bfts[arrow2[cat][2]]] ])   
+    bft_idx = np.argmax(bfts)
+    cand = arrow2[cat]
+    del cand[bft_idx]
+     
+    pt1, pt2 = row[pts[cand[0]]], row[pts[cand[1]]]
+    eta1, eta2 = row[etas[cand[0]]], row[etas[cand[1]]]
+    phi1, phi2 = row[phis[cand[0]]], row[phis[cand[1]]]
+    m1, m2 = row[ms[cand[0]]], row[ms[cand[1]]]
+    higgs_mass_2 = calculate_mass(pt1, eta1, phi1, m1, pt2, eta2, phi2, m2)
+ 
+    out = [higgs_mass_1, higgs_mass_2]
+    return out   
+
+
+def Second_higgs_5_2(row):
+    cat = row["pred_bfh"]
     pts = ["bJet1_pt", "bJet2_pt", "bJet3_pt", "bJet4_pt", "bJet5_pt"]
     etas = ["bJet1_eta", "bJet2_eta", "bJet3_eta", "bJet4_eta", "bJet5_eta"]
     phis = ["bJet1_phi", "bJet2_phi", "bJet3_phi", "bJet4_phi", "bJet5_phi"]
@@ -62,27 +218,24 @@ def higgs_5_2(row):
     pxs = [px1, px2]; pys = [py1, py2]; pzs = [pz1, pz2]; Es = [E1, E2]
 
     close_mass = 999
-    for i in range(len(pxs)):
-        px_1, py_1, pz_1, E_1 = pxs[i], pys[i], pzs[i], Es[i]
-        for j in range(i+1, len(pxs)):
-            px_2, py_2, pz_2, E_2 = pxs[j], pys[j], pzs[j], Es[j]
+    px_1, py_1, pz_1, E_1 = pxs[0], pys[0], pzs[0], Es[0]
+    px_2, py_2, pz_2, E_2 = pxs[1], pys[1], pzs[1], Es[1]
 
-            px = px_1 + px_2 
-            py = py_1 + py_2 
-            pz = pz_1 + pz_2 
-            E = E_1 + E_2
+    px = px_1 + px_2 
+    py = py_1 + py_2 
+    pz = pz_1 + pz_2 
+    E = E_1 + E_2
 
-            mass = np.sqrt(E**2 - px**2 - py**2 - pz**2)
-            if abs(mass-125) < abs(close_mass-125): 
-                close_mass = mass
+    mass = np.sqrt(E**2 - px**2 - py**2 - pz**2)
+    if abs(mass-125) < abs(close_mass-125): 
+        close_mass = mass
 
     if close_mass != 999:
         return close_mass
     else: return 0
-
 '''
 def top_1(row):
-    cat = row["pred_bcat"]
+    cat = row["pred_bfh"]
     pts = ["bJet1_pt", "bJet2_pt", "bJet3_pt", "bJet4_pt", "bJet5_pt"]
     etas = ["bJet1_eta", "bJet2_eta", "bJet3_eta", "bJet4_eta", "bJet5_eta"]
     phis = ["bJet1_phi", "bJet2_phi", "bJet3_phi", "bJet4_phi", "bJet5_phi"]
@@ -141,8 +294,8 @@ def X_higgs(row):
     X_Higgs = ((HiggsMass - mass)/HiggsWidth)**2
     return X_Higgs
 
-def bfh_dr(row):
-    cat = row["pred_bcat"]
+def bb_dr(row):
+    cat = row["pred_bfh"]
     pts = ["bJet1_pt", "bJet2_pt", "bJet3_pt", "bJet4_pt", "bJet5_pt"]
     etas = ["bJet1_eta", "bJet2_eta", "bJet3_eta", "bJet4_eta", "bJet5_eta"]
     phis = ["bJet1_phi", "bJet2_phi", "bJet3_phi", "bJet4_phi", "bJet5_phi"]
@@ -158,8 +311,31 @@ def bfh_dr(row):
     out = np.sqrt( (eta1-eta2)**2 + (phi1-phi2)**2 )
     return out
 
+def bfh_Vars(row):
+    cat = row["pred_bfh"]
+    pts = ["bJet1_pt", "bJet2_pt", "bJet3_pt", "bJet4_pt", "bJet5_pt"]
+    etas = ["bJet1_eta", "bJet2_eta", "bJet3_eta", "bJet4_eta", "bJet5_eta"]
+    phis = ["bJet1_phi", "bJet2_phi", "bJet3_phi", "bJet4_phi", "bJet5_phi"]
+    ms = ["bJet1_mass", "bJet2_mass", "bJet3_mass", "bJet4_mass", "bJet5_mass"]
+    arrow = {0:[0,1], 1:[0,2], 2:[0,3], 3:[0,4], 4:[1,2], 5:[1,3], 6:[1,4], 7:[2,3], 8:[2,4], 9:[3,4]}
+    if cat == 10: return [0, 0, 0, 0, 0];
+
+    pt1, pt2 = row[pts[arrow[cat][0]]], row[pts[arrow[cat][1]]]
+    eta1, eta2 = row[etas[arrow[cat][0]]], row[etas[arrow[cat][1]]]
+    phi1, phi2 = row[phis[arrow[cat][0]]], row[phis[arrow[cat][1]]]
+    m1, m2 = row[ms[arrow[cat][0]]], row[ms[arrow[cat][1]]]
+   
+    bb_dr = np.sqrt( (eta1-eta2)**2 + (phi1-phi2)**2 )
+    bb_Ht = pt1 + pt2
+    bb_dEta = abs(eta1-eta2)
+    bb_dPhi = abs(phi1-phi2)
+    bb_mbmb = m1+m2
+    out = [bb_dr, bb_Ht, bb_dEta, bb_dPhi, bb_mbmb]
+    return out
+
+
 def higgs_4(row):
-    cat = row["pred_bcat"]
+    cat = row["pred_bfh"]
     pts = ["bJet1_pt", "bJet2_pt", "bJet3_pt", "bJet4_pt"]
     etas = ["bJet1_eta", "bJet2_eta", "bJet3_eta", "bJet4_eta"]
     phis = ["bJet1_phi", "bJet2_phi", "bJet3_phi", "bJet4_phi"]


### PR DESCRIPTION
1. New file : dnn1_bft.py    -> Same as dnn1.py but with bJet ID w.r.t. "top" not higgs.
2. b from top discriminator is added to dnn2.py 
3. Not Using One Hot Encoding for bJet_ID info -> Using discriminators directly : 15 New Vars (2bfh_1to10 & bft_1to5)
4. "higgs_mass_sub" variable is reconstructed from the left bJets excluding the one with the biggest bft score. 
    example : 
                      If pred_bfh = 0 -> b1 + b2 = "higgs_mass"
                      The left bJets : b3, b4, b5. 
                      If bft_3 = 0.12, bft_4 = 0.05, **bft_5 = 0.31** -> b3 + b4 = "higgs_sub_mass"
6. New plotting function : "utils/var_functions.py/plot_multi_histograms_dfs" 
7. Cutflow.py update with DNN efficiency input. 